### PR TITLE
Allow injecting a logger

### DIFF
--- a/pyaugmecon/logs.py
+++ b/pyaugmecon/logs.py
@@ -26,10 +26,11 @@ class Logs:
 
         # Set the log directory and log file path
         self.logdir = f"{Path().absolute()}/{self.opts.logdir}/"
-        self.logfile = f"{self.logdir}{self.opts.log_name}.log"
-        self.logger = logging.getLogger(opts.log_name)  # Set up logger object
-        self.handler = logging.FileHandler(self.logfile)  # Set up handler object for logger object
-        self.formatter = logging.Formatter("[%(asctime)s] %(message)s")  # Set up formatter object for handler object
-        self.handler.setFormatter(self.formatter)  # Add formatter object to handler object
-        self.logger.addHandler(self.handler)  # Add handler object to logger object
-        self.handler.setLevel(logging.INFO)  # Set logging level for the handler object
+        if not opts.external_logger:
+            logfile = f"{self.logdir}{self.opts.log_name}.log"
+            logger = logging.getLogger(opts.log_name)  # Set up logger object
+            handler = logging.FileHandler(logfile)  # Set up handler object for logger object
+            formatter = logging.Formatter("[%(asctime)s] %(message)s")  # Set up formatter object for handler object
+            handler.setFormatter(formatter)  # Add formatter object to handler object
+            logger.addHandler(handler)  # Add handler object to logger object
+            handler.setLevel(logging.INFO)  # Set logging level for the handler object

--- a/pyaugmecon/options.py
+++ b/pyaugmecon/options.py
@@ -37,18 +37,19 @@ class Options:
         self.process_timeout = opts.get("process_timeout", None)  # Timeout for processes
         self.solver_name = opts.get("solver_name", "gurobi")  # Name of solver
         self.solver_io = opts.get("solver_io", "python")  # IO mode of solver
+        self.external_logger = "log_name" in opts # whether to use an already set up logger or not
 
         self.solver_opts = solver_opts  # Solver options
         self.solver_opts["MIPGap"] = solver_opts.get("MIPGap", 0.0)  # MIP gap
         self.solver_opts["NonConvex"] = solver_opts.get("NonConvex", 2)  # Nonconvex setting
 
-        # Remove None values from dict when user has overriden them
+        # Remove None values from dict when user has overridden them
         for key, value in dict(self.solver_opts).items():
             if value is None or value:
                 del self.solver_opts[key]
 
         self.time_created = time.strftime("%Y%m%d-%H%M%S")  # Time the options object was created
-        self.log_name = self.name + "_" + str(self.time_created)  # Name of log file
+        self.log_name = opts.get("log_name", self.name + "_" + str(self.time_created))  # Name of log file
 
     def log(self):
         """


### PR DESCRIPTION
Adds the ability to use a logger that has been configured outside of PyAUGMECON.
Behavior of setting up own logger remains default.
Only if `log_name` is configured in the config options, setup is skipped and the passed logger is used.