### PR TITLE
Allow disabling print()s

### DIFF
--- a/pyaugmecon/helper.py
+++ b/pyaugmecon/helper.py
@@ -1,6 +1,8 @@
 import time
 from multiprocessing import Lock, Value
 
+from pyaugmecon.options import Options
+
 
 class Helper:
     """A class of helper functions."""
@@ -55,11 +57,12 @@ class Timer:
 class ProgressBar:
     """A class for displaying a progress bar."""
 
-    def __init__(self, counter: Counter, total: int, init_message: str = ""):
+    def __init__(self, counter: Counter, total: int, opts: Options):
         """Initializes the progress bar with a counter and a total number of iterations."""
+        self.opts = opts
         self.counter = counter
         self.total = total
-        self.message = init_message
+        self.message = ""
         self.bar = ""
 
     def set_message(self, message):
@@ -70,6 +73,9 @@ class ProgressBar:
 
     def print(self, force):
         """Prints the progress bar."""
+        if self.opts.disable_output:
+            return
+
         bar_len = 40
 
         progress = self.counter.value() / float(self.total)

--- a/pyaugmecon/model.py
+++ b/pyaugmecon/model.py
@@ -43,7 +43,7 @@ class Model:
 
         # Setup progress bar
         self.to_solve = opts.gp ** (self.n_obj - 1) + self.n_obj**2
-        self.progress = ProgressBar(Counter(), self.to_solve)
+        self.progress = ProgressBar(Counter(), self.to_solve, opts)
 
         self.models_solved = Counter()
         self.infeasibilities = Counter()

--- a/pyaugmecon/options.py
+++ b/pyaugmecon/options.py
@@ -35,6 +35,7 @@ class Options:
         self.output_excel = opts.get("output_excel", True)  # Whether to output to Excel
         self.process_logging = opts.get("process_logging", False)  # Whether to enable process logging
         self.process_timeout = opts.get("process_timeout", None)  # Timeout for processes
+        self.disable_output = opts.get("disable_output", False)  # Whether to disable printing to console
         self.solver_name = opts.get("solver_name", "gurobi")  # Name of solver
         self.solver_io = opts.get("solver_io", "python")  # IO mode of solver
 

--- a/pyaugmecon/pyaugmecon.py
+++ b/pyaugmecon/pyaugmecon.py
@@ -17,7 +17,7 @@ from pyaugmecon.queue_handler import QueueHandler
 
 
 class PyAugmecon:
-    def __init__(self, model: PyomoModel, opts: Options, solver_opts={}):
+    def __init__(self, model: PyomoModel, opts: dict, solver_opts: dict = {}):
         """
         Initialize a PyAugmecon object.
 
@@ -222,12 +222,13 @@ class PyAugmecon:
 
         # Compute the total runtime and print a summary of the results
         self.runtime = round(self.runtime.get(), 2)
-        Helper.clear_line()
-        print(
-            f"Solved {self.model.models_solved.value()} models for "
-            f"{self.num_unique_pareto_sols} unique Pareto solutions in "
-            f"{self.runtime} seconds"
-        )
+        if not self.opts.disable_output:
+            Helper.clear_line()
+            print(
+                f"Solved {self.model.models_solved.value()} models for "
+                f"{self.num_unique_pareto_sols} unique Pareto solutions in "
+                f"{self.runtime} seconds"
+            )
 
         # Log a summary of the results
         self.logger.info(Helper.separator())


### PR DESCRIPTION
Add the options to disable print statements.
print() with \r work fine in a console, but not so much in situations where logs are being streamed.
