### PR TITLE
Correctly enqueue items such that work can be taken by other processes

### DIFF
--- a/pyaugmecon/process_handler.py
+++ b/pyaugmecon/process_handler.py
@@ -60,7 +60,7 @@ class ProcessHandler:
         while self.runtime.get() <= self.opts.process_timeout:
             if not any(p.is_alive() for p in self.procs):  # Check if any process has exited
                 break
-            time.sleep(0.5)
+            time.sleep(1)
         else:
             self.logger.info("Timed out, gracefully stopping all worker process(es)")
             self.queues.empty_job_qs()  # Empty the job queues


### PR DESCRIPTION
Fixes #14

This issue was introduced by a refactor in version 1.0.0 and discovered by @yvanoers. Subblocks are now queued individually instead of as a flattened list. 