### PR TITLE
Wait for processes to exit instead of STOP result

### DIFF
--- a/pyaugmecon/process_handler.py
+++ b/pyaugmecon/process_handler.py
@@ -67,12 +67,16 @@ class ProcessHandler:
 
     def join(self):
         """
-        Wait for the worker processes to finish.
+        Wait a bit for the worker processes to finish.
+        Returns true when all of them have finished, false otherwise.
         """
-        self.logger.info(f"Joining {self.queues.proc_count} worker process(es)")
-
         if self.opts.process_timeout:
             self.timeout.join()  # Wait for the timer thread to finish
 
-        for p in self.procs:
-            p.join()  # Wait for each process to finish
+        return all(p.join(1) == None and p.exitcode != None for p in self.procs)
+
+    def all_killed(self):
+        """
+        Returns whether all workers were killed or not.
+        """
+        return all(p.exitcode < 0 for p in self.procs)

--- a/pyaugmecon/process_handler.py
+++ b/pyaugmecon/process_handler.py
@@ -75,8 +75,8 @@ class ProcessHandler:
 
         return all(p.join(1) == None and p.exitcode != None for p in self.procs)
 
-    def all_killed(self):
+    def any_killed(self):
         """
         Returns whether all workers were killed or not.
         """
-        return all(p.exitcode < 0 for p in self.procs)
+        return any(p.exitcode < 0 for p in self.procs)

--- a/pyaugmecon/pyaugmecon.py
+++ b/pyaugmecon/pyaugmecon.py
@@ -79,7 +79,7 @@ class PyAugmecon:
         self.unprocessed_sols.extend(self.queues.get_result())
 
         # In case all worker processes were killed, not all work may have been done.
-        if self.procs.any_killed():
+        if self.procs.any_killed:
             raise Exception("At least one worker exited prematurely, not all computations may have been done.")
 
         # Clean the pickled model

--- a/pyaugmecon/pyaugmecon.py
+++ b/pyaugmecon/pyaugmecon.py
@@ -79,8 +79,8 @@ class PyAugmecon:
         self.unprocessed_sols.extend(self.queues.get_result())
 
         # In case all worker processes were killed, not all work may have been done.
-        if self.procs.all_killed():
-            raise Exception("All workers exited prematurely, not all computations may have done.")
+        if self.procs.any_killed():
+            raise Exception("At least one worker exited prematurely, not all computations may have been done.")
 
         # Clean the pickled model
         self.model.clean()

--- a/pyaugmecon/pyaugmecon.py
+++ b/pyaugmecon/pyaugmecon.py
@@ -72,8 +72,15 @@ class PyAugmecon:
 
         # Start processes and wait for results
         self.procs.start()
-        self.unprocesssed_sols = self.queues.get_result()
-        self.procs.join()
+        self.unprocessed_sols = []
+        while not self.procs.join():
+            self.unprocessed_sols.extend(self.queues.get_result())
+        # One last sweep to make sure all results have been collected
+        self.unprocessed_sols.extend(self.queues.get_result())
+
+        # In case all worker processes were killed, not all work may have been done.
+        if self.procs.all_killed():
+            raise Exception("All workers exited prematurely, not all computations may have done.")
 
         # Clean the pickled model
         self.model.clean()
@@ -97,7 +104,7 @@ class PyAugmecon:
 
         # Merge solutions into one dictionary and remove duplicates
         self.sols = {}
-        for sol in self.unprocesssed_sols:
+        for sol in self.unprocessed_sols:
             self.sols.update(sol)
         self.num_sols = len(self.sols)
 

--- a/pyaugmecon/solver_process.py
+++ b/pyaugmecon/solver_process.py
@@ -162,3 +162,7 @@ class SolverProcess(Process):
                     log += f"solutions: {sols}"
                     if self.opts.process_logging:
                         self.logger.info(log)
+
+        if self.opts.process_logging:
+            # If process logging is enabled, log that the process exited
+            self.logger.info(f"Process {self.p_num} finished")


### PR DESCRIPTION
The current implementation waits for all results and stops waiting based on a "STOP" signal one for each spawned worker.
This causes the main loop to wait forever if any of the subprocesses gets killed, e.g. by the OOM killer, because the STOP signal isn't sent. We ran into this problem.

This change does away with the STOP marker. The processes themselves are waited upon and while they run the results are collected.

If a worker gets killed, the remaining work gets picked up by the other workers.
However, when all workers have exited, but any one of them was killed, an exception is raised to signal not all computations may have been done.
This behavior may need to change to either
--  only raise an exception if it is sure some work was not done, or
-- terminate the other workers early because an exception will be thrown when they're done anyway.
