### PR TITLE
fixed bug within options.py

### DIFF
--- a/pyaugmecon/options.py
+++ b/pyaugmecon/options.py
@@ -44,7 +44,7 @@ class Options:
 
         # Remove None values from dict when user has overriden them
         for key, value in dict(self.solver_opts).items():
-            if value is None or value:
+            if value is None or not value:
                 del self.solver_opts[key]
 
         self.time_created = time.strftime("%Y%m%d-%H%M%S")  # Time the options object was created

--- a/pyaugmecon/options.py
+++ b/pyaugmecon/options.py
@@ -44,7 +44,7 @@ class Options:
 
         # Remove None values from dict when user has overriden them
         for key, value in dict(self.solver_opts).items():
-            if value is None or not value:
+            if value is None or (not value and value != 0):
                 del self.solver_opts[key]
 
         self.time_created = time.strftime("%Y%m%d-%H%M%S")  # Time the options object was created


### PR DESCRIPTION
When I unsuccessfully tried to pass additional solver options, I stumbled across this loop and if statement in the options.py file. If I'm not mistaken, only a simple negation operator is missing for the loop to work as intended. 
